### PR TITLE
 Text 2 geoparquet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__
 _build
+.ipynb_checkpoints/
+icethk_all.parquet

--- a/1_Experimental_Variogram.ipynb
+++ b/1_Experimental_Variogram.ipynb
@@ -20,6 +20,7 @@
     "# load dependencies\n",
     "import numpy as np\n",
     "import pandas as pd\n",
+    "import geopandas as gpd\n",
     "import skgstat as skg\n",
     "from sklearn.preprocessing import QuantileTransformer\n",
     "import matplotlib.pyplot as plt\n",
@@ -118,6 +119,9 @@
    ],
    "source": [
     "df_bed = pd.read_csv('data/greenland_test_data.csv')\n",
+    "## importing icethk data \n",
+    "gdf_bed = gdf = gpd.read_parquet(\"icethk_all.parquet\")\n",
+    "\n",
     "\n",
     "# remove erroneously high values due to bad bed picks\n",
     "df_bed = df_bed[df_bed['Bed'] <= 700]\n",
@@ -578,7 +582,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.10.20"
   }
  },
  "nbformat": 4,

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,21 @@
+name: hackdays-2026
+channels:
+  - conda-forge
+dependencies:
+  - python=3.10
+  - matplotlib-base
+  - numpy
+  - pandas 
+  - pip
+  - scikit-learn
+  - scikit-gstat
+  - tqdm
+
+  # dev dependencies
+  - earthaccess
+  - geopandas
+  - pyarrow
+  - jupyter
+
+  - pip:
+    - gstatsim

--- a/txt_to_geoparquet.ipynb
+++ b/txt_to_geoparquet.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 1,
    "id": "fd104524-24fa-4435-9e14-fe536f52c5e0",
    "metadata": {},
    "outputs": [],
@@ -16,7 +16,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 2,
+   "id": "45f657f1-a537-4ccf-aeb2-2a3cec550961",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "COLUMNS = [\n",
+    "    \"YEAR\", \"DOY\", \"SOD\",\n",
+    "    \"LON\", \"LAT\",\n",
+    "    \"ICE_THICK\", \"SRF_RNG\", \"BED_ELEVATION\", \"SURFACE_ELEVATION\",\n",
+    "    \"BED_REFLECT\", \"SRF_REFLECT\", \"AIRCRAFT_ROLL\"\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
    "id": "6fa013bf-7c7a-4004-b614-5a415bbc1b48",
    "metadata": {},
    "outputs": [
@@ -31,10 +46,10 @@
     {
      "data": {
       "text/plain": [
-       "<earthaccess.auth.Auth at 0x10461c910>"
+       "<earthaccess.auth.Auth at 0x107fa2b00>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -45,45 +60,471 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "id": "8182fa28-94c5-4731-9029-04521b246e6f",
+   "execution_count": 4,
+   "id": "b7f1aebd-7856-4fcb-946b-34403c5d396a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# this dataset is here\n",
-    "# https://search.earthdata.nasa.gov/search/granules?p=C3204979277-NSIDC_CPRD&pg[0][v]=f&pg[0][gsk]=-start_date\n",
-    "results = earthaccess.search_data(\n",
-    "    concept_id=\"C3204979277-NSIDC_CPRD\",\n",
-    "    bounding_box=(-180, -90, 180, -60),       # Antarctic coverage\n",
-    "    count=500,\n",
-    ")"
+    "def build_geoparquet(input_dir: str | Path, out_path: str | Path):\n",
+    "    \"\"\"\n",
+    "    Batch-convert a directory of IceBridge HiCARS ice thickness text files\n",
+    "    to a single GeoParquet file.\n",
+    "\n",
+    "    Reads all ``*.txt`` files in ``input_dir``, concatenates them, drops\n",
+    "    rows with missing coordinates, and constructs point geometries from\n",
+    "    LON/LAT (EPSG:4326). The data is reprojected to Antarctic polar\n",
+    "    stereographic (EPSG:3031) and projected ``X``/``Y`` coordinates are\n",
+    "    written as explicit columns alongside the geometry for direct use\n",
+    "    with gstatsim.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    input_dir : str or Path\n",
+    "        Directory containing ``*_icethk.txt`` files (IR1HI2 and/or IR2HI2).\n",
+    "    out_path : str or Path\n",
+    "        Destination path for the output GeoParquet file.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    gpd.GeoDataFrame\n",
+    "        GeoDataFrame in EPSG:3031 with all input columns plus ``X``, ``Y``,\n",
+    "        ``source_file``, and ``instrument``.\n",
+    "    \"\"\"\n",
+    "    input_dir = Path(input_dir)\n",
+    "    files = sorted(input_dir.glob(\"*.txt\"))\n",
+    "    print(f\"Found {len(files)} files\")\n",
+    "\n",
+    "    chunks = [read_icethk(f) for f in files]\n",
+    "    df = pd.concat(chunks, ignore_index=True)\n",
+    "    print(f\"Total rows (including NaN positions): {len(df):,}\")\n",
+    "\n",
+    "    df = df.dropna(subset=[\"LON\", \"LAT\"])\n",
+    "    print(f\"Rows with valid positions: {len(df):,}\")\n",
+    "\n",
+    "    gdf = gpd.GeoDataFrame(\n",
+    "        df,\n",
+    "        geometry=gpd.points_from_xy(df[\"LON\"], df[\"LAT\"]),\n",
+    "        crs=\"EPSG:4326\",\n",
+    "    )\n",
+    "\n",
+    "    gdf = gdf.to_crs(\"EPSG:3031\")\n",
+    "    gdf[\"X\"] = gdf.geometry.x\n",
+    "    gdf[\"Y\"] = gdf.geometry.y\n",
+    "\n",
+    "    gdf.to_parquet(out_path, compression=\"snappy\")\n",
+    "    print(f\"Written → {out_path}\")\n",
+    "    return gdf"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "id": "c6205763-50ab-4d74-9041-b43a046dc987",
+   "execution_count": 5,
+   "id": "30e21bf0-c4b6-4930-9976-4461609fc699",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def read_icethk(path: Path) -> pd.DataFrame:\n",
+    "    \"\"\"\n",
+    "    Read a single IceBridge HiCARS ice thickness text file into a DataFrame.\n",
+    "\n",
+    "    Parses the variable-length comment header by scanning for the\n",
+    "    ``Length_of_header`` metadata field, then reads the space-delimited\n",
+    "    data block. Missing values (``nan`` in the raw files) are preserved\n",
+    "    as ``NaN``. A ``source_file`` column and an ``instrument`` column\n",
+    "    (``HiCARS1`` or ``HiCARS2``, inferred from the filename prefix) are\n",
+    "    appended for provenance tracking.\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    path : Path\n",
+    "        Path to a ``*_icethk.txt`` file (IR1HI2 or IR2HI2 format).\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    pd.DataFrame\n",
+    "        DataFrame with columns: YEAR, DOY, SOD, LON, LAT, ICE_THICK,\n",
+    "        SRF_RNG, BED_ELEVATION, SURFACE_ELEVATION, BED_REFLECT,\n",
+    "        SRF_REFLECT, AIRCRAFT_ROLL, source_file, instrument.\n",
+    "        Rows with missing LON/LAT are retained at this stage.\n",
+    "    \"\"\"\n",
+    "    with open(path) as f:\n",
+    "        for i, line in enumerate(f):\n",
+    "            if \"Length_of_header:\" in line:\n",
+    "                header_lines = int(line.split(\":\")[-1].strip().split()[0])\n",
+    "                break\n",
+    "\n",
+    "    df = pd.read_csv(\n",
+    "        path,\n",
+    "        skiprows=header_lines,\n",
+    "        sep=r\"\\s+\",\n",
+    "        names=COLUMNS,\n",
+    "        na_values=\"nan\",\n",
+    "    )\n",
+    "    df[\"source_file\"] = path.name\n",
+    "    df[\"instrument\"] = \"HiCARS1\" if \"IR1HI2\" in path.name else \"HiCARS2\"\n",
+    "    return df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "8182fa28-94c5-4731-9029-04521b246e6f",
    "metadata": {},
    "outputs": [
     {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "C3204979277-NSIDC_CPRD: 243 granules\n"
+     ]
+    },
+    {
      "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "66cb996733d94cc888cb579cb4ad2df9",
+       "version_major": 2,
+       "version_minor": 0
+      },
       "text/plain": [
-       "243"
+       "QUEUEING TASKS | :   0%|          | 0/243 [00:00<?, ?it/s]"
       ]
      },
-     "execution_count": 19,
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "59a9c8a175e14dacb600962d72293325",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "PROCESSING TASKS | :   0%|          | 0/243 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "201a74dedd0b415fa0e125af1a48c1da",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "COLLECTING RESULTS | :   0%|          | 0/243 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "C3204982997-NSIDC_CPRD: 617 granules\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "2d10db892d72418a90ae330b1b19a681",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "QUEUEING TASKS | :   0%|          | 0/617 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "4581e8e6038c492eade8d09b39692e0a",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "PROCESSING TASKS | :   0%|          | 0/617 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "a6bfe4c30979492aa46e7277c50a7bfe",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "COLLECTING RESULTS | :   0%|          | 0/617 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 860 files\n",
+      "Total rows (including NaN positions): 9,700,516\n",
+      "Rows with valid positions: 9,372,683\n",
+      "Written → icethk_all.parquet\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Dataset landing pages:\n",
+    "# https://nsidc.org/data/ir1hi2/versions/1\n",
+    "# https://nsidc.org/data/ir2hi2/versions/1\n",
+    "\n",
+    "\n",
+    "with tempfile.TemporaryDirectory() as tmpdir:\n",
+    "    for concept_id in [\"C3204979277-NSIDC_CPRD\", \"C3204982997-NSIDC_CPRD\"]:\n",
+    "        results = earthaccess.search_data(concept_id=concept_id)\n",
+    "        print(f\"{concept_id}: {len(results)} granules\")\n",
+    "        earthaccess.download(results, local_path=tmpdir)\n",
+    "        \n",
+    "    gdf = build_geoparquet(tmpdir, \"icethk_all.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "0c7ea92b-a956-4f64-9bcf-5ed0b56e3b79",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(9372683, 17)\n",
+      "YEAR                    int64\n",
+      "DOY                     int64\n",
+      "SOD                   float64\n",
+      "LON                   float64\n",
+      "LAT                   float64\n",
+      "ICE_THICK             float64\n",
+      "SRF_RNG               float64\n",
+      "BED_ELEVATION         float64\n",
+      "SURFACE_ELEVATION     float64\n",
+      "BED_REFLECT           float64\n",
+      "SRF_REFLECT           float64\n",
+      "AIRCRAFT_ROLL         float64\n",
+      "source_file            object\n",
+      "instrument             object\n",
+      "geometry             geometry\n",
+      "X                     float64\n",
+      "Y                     float64\n",
+      "dtype: object\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>YEAR</th>\n",
+       "      <th>DOY</th>\n",
+       "      <th>SOD</th>\n",
+       "      <th>LON</th>\n",
+       "      <th>LAT</th>\n",
+       "      <th>ICE_THICK</th>\n",
+       "      <th>SRF_RNG</th>\n",
+       "      <th>BED_ELEVATION</th>\n",
+       "      <th>SURFACE_ELEVATION</th>\n",
+       "      <th>BED_REFLECT</th>\n",
+       "      <th>SRF_REFLECT</th>\n",
+       "      <th>AIRCRAFT_ROLL</th>\n",
+       "      <th>source_file</th>\n",
+       "      <th>instrument</th>\n",
+       "      <th>geometry</th>\n",
+       "      <th>X</th>\n",
+       "      <th>Y</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>531</th>\n",
+       "      <td>2009</td>\n",
+       "      <td>2</td>\n",
+       "      <td>33057.5535</td>\n",
+       "      <td>161.096539</td>\n",
+       "      <td>-80.058225</td>\n",
+       "      <td>532.63</td>\n",
+       "      <td>1458.61</td>\n",
+       "      <td>-520.62</td>\n",
+       "      <td>-1458.61</td>\n",
+       "      <td>-50.00</td>\n",
+       "      <td>-21.90</td>\n",
+       "      <td>11.11</td>\n",
+       "      <td>IR1HI2_2009002_ICP1_JKB1a_F05T02a_icethk.txt</td>\n",
+       "      <td>HiCARS1</td>\n",
+       "      <td>POINT (350801.917 -1024406.626)</td>\n",
+       "      <td>350801.916733</td>\n",
+       "      <td>-1.024407e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>532</th>\n",
+       "      <td>2009</td>\n",
+       "      <td>2</td>\n",
+       "      <td>33057.8034</td>\n",
+       "      <td>161.097043</td>\n",
+       "      <td>-80.058075</td>\n",
+       "      <td>532.42</td>\n",
+       "      <td>1458.25</td>\n",
+       "      <td>-520.06</td>\n",
+       "      <td>12.36</td>\n",
+       "      <td>-48.79</td>\n",
+       "      <td>-17.63</td>\n",
+       "      <td>11.09</td>\n",
+       "      <td>IR1HI2_2009002_ICP1_JKB1a_F05T02a_icethk.txt</td>\n",
+       "      <td>HiCARS1</td>\n",
+       "      <td>POINT (350798.224 -1024425.242)</td>\n",
+       "      <td>350798.223863</td>\n",
+       "      <td>-1.024425e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>533</th>\n",
+       "      <td>2009</td>\n",
+       "      <td>2</td>\n",
+       "      <td>33058.0535</td>\n",
+       "      <td>161.097547</td>\n",
+       "      <td>-80.057925</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1460.26</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>10.35</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>-16.40</td>\n",
+       "      <td>11.08</td>\n",
+       "      <td>IR1HI2_2009002_ICP1_JKB1a_F05T02a_icethk.txt</td>\n",
+       "      <td>HiCARS1</td>\n",
+       "      <td>POINT (350794.531 -1024443.859)</td>\n",
+       "      <td>350794.530694</td>\n",
+       "      <td>-1.024444e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>534</th>\n",
+       "      <td>2009</td>\n",
+       "      <td>2</td>\n",
+       "      <td>33058.3032</td>\n",
+       "      <td>161.098051</td>\n",
+       "      <td>-80.057774</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1464.00</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>6.60</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>-19.77</td>\n",
+       "      <td>10.98</td>\n",
+       "      <td>IR1HI2_2009002_ICP1_JKB1a_F05T02a_icethk.txt</td>\n",
+       "      <td>HiCARS1</td>\n",
+       "      <td>POINT (350790.873 -1024462.579)</td>\n",
+       "      <td>350790.872679</td>\n",
+       "      <td>-1.024463e+06</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>535</th>\n",
+       "      <td>2009</td>\n",
+       "      <td>2</td>\n",
+       "      <td>33058.5532</td>\n",
+       "      <td>161.098556</td>\n",
+       "      <td>-80.057624</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1459.10</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>11.50</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>-14.17</td>\n",
+       "      <td>10.64</td>\n",
+       "      <td>IR1HI2_2009002_ICP1_JKB1a_F05T02a_icethk.txt</td>\n",
+       "      <td>HiCARS1</td>\n",
+       "      <td>POINT (350787.161 -1024481.202)</td>\n",
+       "      <td>350787.161030</td>\n",
+       "      <td>-1.024481e+06</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     YEAR  DOY         SOD         LON        LAT  ICE_THICK  SRF_RNG  \\\n",
+       "531  2009    2  33057.5535  161.096539 -80.058225     532.63  1458.61   \n",
+       "532  2009    2  33057.8034  161.097043 -80.058075     532.42  1458.25   \n",
+       "533  2009    2  33058.0535  161.097547 -80.057925        NaN  1460.26   \n",
+       "534  2009    2  33058.3032  161.098051 -80.057774        NaN  1464.00   \n",
+       "535  2009    2  33058.5532  161.098556 -80.057624        NaN  1459.10   \n",
+       "\n",
+       "     BED_ELEVATION  SURFACE_ELEVATION  BED_REFLECT  SRF_REFLECT  \\\n",
+       "531        -520.62           -1458.61       -50.00       -21.90   \n",
+       "532        -520.06              12.36       -48.79       -17.63   \n",
+       "533            NaN              10.35          NaN       -16.40   \n",
+       "534            NaN               6.60          NaN       -19.77   \n",
+       "535            NaN              11.50          NaN       -14.17   \n",
+       "\n",
+       "     AIRCRAFT_ROLL                                   source_file instrument  \\\n",
+       "531          11.11  IR1HI2_2009002_ICP1_JKB1a_F05T02a_icethk.txt    HiCARS1   \n",
+       "532          11.09  IR1HI2_2009002_ICP1_JKB1a_F05T02a_icethk.txt    HiCARS1   \n",
+       "533          11.08  IR1HI2_2009002_ICP1_JKB1a_F05T02a_icethk.txt    HiCARS1   \n",
+       "534          10.98  IR1HI2_2009002_ICP1_JKB1a_F05T02a_icethk.txt    HiCARS1   \n",
+       "535          10.64  IR1HI2_2009002_ICP1_JKB1a_F05T02a_icethk.txt    HiCARS1   \n",
+       "\n",
+       "                            geometry              X             Y  \n",
+       "531  POINT (350801.917 -1024406.626)  350801.916733 -1.024407e+06  \n",
+       "532  POINT (350798.224 -1024425.242)  350798.223863 -1.024425e+06  \n",
+       "533  POINT (350794.531 -1024443.859)  350794.530694 -1.024444e+06  \n",
+       "534  POINT (350790.873 -1024462.579)  350790.872679 -1.024463e+06  \n",
+       "535  POINT (350787.161 -1024481.202)  350787.161030 -1.024481e+06  "
+      ]
+     },
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "len(results)\n"
+    "gdf = gpd.read_parquet(\"icethk_all.parquet\")\n",
+    "print(gdf.shape)\n",
+    "print(gdf.dtypes)\n",
+    "gdf.head()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "726af51a-5690-4392-936b-dfe6bc373567",
+   "id": "6d5cffd0-500b-4e74-a845-717faecc521d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6887c50b-b7b3-4cc5-9fe6-ec4c4759f1a0",
    "metadata": {},
    "outputs": [],
    "source": []

--- a/txt_to_geoparquet.ipynb
+++ b/txt_to_geoparquet.ipynb
@@ -1,0 +1,113 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "fd104524-24fa-4435-9e14-fe536f52c5e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import geopandas as gpd\n",
+    "import pandas as pd\n",
+    "from pathlib import Path\n",
+    "import earthaccess\n",
+    "import tempfile"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "6fa013bf-7c7a-4004-b614-5a415bbc1b48",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "Enter your Earthdata Login username:  roma8902\n",
+      "Enter your Earthdata password:  ········\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<earthaccess.auth.Auth at 0x10461c910>"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "earthaccess.login()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "8182fa28-94c5-4731-9029-04521b246e6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# this dataset is here\n",
+    "# https://search.earthdata.nasa.gov/search/granules?p=C3204979277-NSIDC_CPRD&pg[0][v]=f&pg[0][gsk]=-start_date\n",
+    "results = earthaccess.search_data(\n",
+    "    concept_id=\"C3204979277-NSIDC_CPRD\",\n",
+    "    bounding_box=(-180, -90, 180, -60),       # Antarctic coverage\n",
+    "    count=500,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "c6205763-50ab-4d74-9041-b43a046dc987",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "243"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(results)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "726af51a-5690-4392-936b-dfe6bc373567",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.20"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/txt_to_geoparquet.ipynb
+++ b/txt_to_geoparquet.ipynb
@@ -46,7 +46,7 @@
     {
      "data": {
       "text/plain": [
-       "<earthaccess.auth.Auth at 0x107fa2b00>"
+       "<earthaccess.auth.Auth at 0x10689b940>"
       ]
      },
      "execution_count": 3,
@@ -181,7 +181,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "66cb996733d94cc888cb579cb4ad2df9",
+       "model_id": "c12e03b6adb34dc9ab10ccbddec48e5d",
        "version_major": 2,
        "version_minor": 0
       },
@@ -195,7 +195,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "59a9c8a175e14dacb600962d72293325",
+       "model_id": "052f13dcdc694ba49684e912ed0ec697",
        "version_major": 2,
        "version_minor": 0
       },
@@ -209,7 +209,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "201a74dedd0b415fa0e125af1a48c1da",
+       "model_id": "4491e9649f944d5aaeadb690e9a51d68",
        "version_major": 2,
        "version_minor": 0
       },
@@ -230,7 +230,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "2d10db892d72418a90ae330b1b19a681",
+       "model_id": "0c613408eea147318b7d321d480f88c0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -244,7 +244,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4581e8e6038c492eade8d09b39692e0a",
+       "model_id": "ab5e436fbe9e4cc2a009b9d7724bc956",
        "version_major": 2,
        "version_minor": 0
       },
@@ -258,7 +258,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a6bfe4c30979492aa46e7277c50a7bfe",
+       "model_id": "a8abd5e71f7949c2a722fafbc011d519",
        "version_major": 2,
        "version_minor": 0
       },


### PR DESCRIPTION
Add notebook to convert IceBridge HiCARS ice thickness text files to GeoParquet

- Add conda environment for gstatsim/geoparquet dependencies
- Downloads IR1HI2 and IR2HI2 granules from NSIDC via earthaccess
- Parses variable-length headers and concatenates all flight lines
- Reprojects to EPSG:3031 and writes X/Y columns for gstatsim
- Demonstrates loading GeoParquet into gstatsim variogram workflow